### PR TITLE
Rename initialize to initializePackage

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -11,7 +11,7 @@ const path = require('path')
 
 module.exports = {
 
-  initialize () {
+  initializePackage () {
     const BugsView = require('./bugs-view.js')
     this.debugView = new BugsView()
     this.debugView.observe()
@@ -43,10 +43,10 @@ module.exports = {
           return new BufferedProcess({
             command: apm,
             args,
-            exit: this.initialize.bind(this),
+            exit: this.initializePackage.bind(this),
             options})
         } else {
-          this.initialize()
+          this.initializePackage()
         }
       })
   },


### PR DESCRIPTION
As of Atom 1.14, any method named `initialize` on the main module of a package will be automatically invoked by Atom before calling `activate`. You can read more about the change in this [pull request to Atom's documentation](https://github.com/atom/flight-manual.atom.io/pull/300/files).

Since your package's `initialize` method wasn't written with this behavior in mind, we've renamed it for you to avoid unexpected breakage.

Atom 1.14 should reach the beta channel in early January 2017 and will be on stable in early February 2017. Please merge and test out this PR before then to prevent issues, and let us know if you have any questions.

Thanks for your contributions to the Atom community! :bow:

/cc: @willyelm 