### PR TITLE
Changed how range is get from selection (fixes #14)

### DIFF
--- a/lib/bugs-view.js
+++ b/lib/bugs-view.js
@@ -211,7 +211,7 @@ class BugsView {
               let isFileBreak = this.currentBreakFile.match(sourceFile)
               if (isFileBreak) {
                 // has selected range
-                let range = event.selection.getScreenRange()
+                let range = event.selection.getBufferRange()
                 if (this.task && range && range.start.row === range.end.row) {
                   let text = editor.getTextInBufferRange(range)
                   if (text && text.length > 0) {


### PR DESCRIPTION
Previous code got screenRange and used it to get text from buffer: this caused unexpected behaviours when tabs was used as indentation chars.
This PR fixes #14 